### PR TITLE
Use highlight color from user settings

### DIFF
--- a/vscode/.editorconfig
+++ b/vscode/.editorconfig
@@ -1,0 +1,16 @@
+# editorconfig.org
+root = false
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{xml,html,kt,gradle}]
+indent_size = 4

--- a/vscode/.vscode/extensions.json
+++ b/vscode/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"ms-vscode.vscode-typescript-tslint-plugin"
 	]
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -45,6 +45,22 @@
     ],
     "main": "./out/extension",
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "Codio configuration",
+            "properties": {
+                "codio.cursorColorDarkTheme": {
+                    "type": "string",
+                    "default": "rgb(81,80,82)",
+                    "description": "The color of the cursor in a Codio in a dark theme"
+                },
+                "codio.cursorColorLightTheme": {
+                    "type": "string",
+                    "default": "rgb(255, 255, 255)",
+                    "description": "The color of the cursor in a Codio in a light theme"
+                }
+            }
+        },
         "commands": [
             {
                 "command": "codio.recordCodioAndAddToProject",
@@ -158,7 +174,7 @@
                     "group": "navigation"
                 }
             ],
-            "view/title" :  [
+            "view/title": [
                 {
                     "command": "codio.recordCodioAndAddToProject",
                     "when": "view == codioMessages && !inCodioRecording",
@@ -171,14 +187,14 @@
                 }
             ]
         },
-		"views": {
-			"explorer": [
-				{
-					"id": "codioMessages",
+        "views": {
+            "explorer": [
+                {
+                    "id": "codioMessages",
                     "name": "Codios"
-				}
-			]
-		}
+                }
+            ]
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/vscode/src/user_interface/Viewers.ts
+++ b/vscode/src/user_interface/Viewers.ts
@@ -58,15 +58,10 @@ export class CodiosDataProvider implements vscode.TreeDataProvider<vscode.TreeIt
 
 
 export const cursorStyle = vscode.window.createTextEditorDecorationType({
-    backgroundColor: new vscode.ThemeColor('editorCursor.foreground'),
-    borderColor: new vscode.ThemeColor('editorCursor.foreground'),
-    dark: {
-      color: 'rgb(81,80,82)',
-    },
-    light: {
-      // used for light colored themes
-      color: 'rgb(255, 255, 255)',
-    },
-    borderStyle: 'solid',
-    borderWidth: '1px',
-  });
+  dark: {
+    backgroundColor: vscode.workspace.getConfiguration('codio').get<string>('cursorColorDarkTheme'),
+  },
+  light: {
+    backgroundColor: vscode.workspace.getConfiguration('codio').get<string>('cursorColorLightTheme'),
+  },
+});


### PR DESCRIPTION
## Issue
Addresses https://github.com/wix-incubator/codio/issues/21

## Description
- Gets highlight color from user preferences
- Adds editor config for vscode folder (perhaps this should be at the root of the whole repo but I was just working in vscode)
- Changes recommended vscode plugin from a deprecated plugin to an official Microsoft plugin

**Note:** The issue with this is that the `cursorColor` is instantiated when and only when the plugin loads. So if they user changes their settings then that won't apply until they close and reopen the editor again. This is less than ideal but at least an improvement from having no options. I tried to change this `cursorColor` to be a function `getCursorColor` that would get the settings values when the function is called.

The issue with this is that we need to unhighlight text with the very same `TextEditorDecoration` object, otherwise it won't unhighlight it properly. In order to do that, we need to store that object somewhere. First, I tried to store it on the `context.globalState` and the `context.workspaceContext` but then I needed to pass down the plugin context through lots of different functions for that to be used (in a prop drilling kind of way).

After that, I tried to store it as a property on the `Editor` class, which seemed like it would work. If we do that we'd need to change many functions to be arrow functions (or bind `this`) so `this` would be the `this` for the Editor (doing that wouldn't be an issue because you're not accessing any other `this` objects within the functions that are called by `Editor`). I started down that route but then couldn't get it to work for some reason. If you have thoughts I'm open to them. Otherwise I propose that we take this incremental improvement and then dig into it further later.

As part of this PR we could also make a note in the settings that users need to restart the editor for this setting change to take effect. Any other comments are welcome here.