### PR TITLE
Handle Play Codio From 'tasks.json' File with playCodioTask Command.

### DIFF
--- a/vscode/codio.d.ts
+++ b/vscode/codio.d.ts
@@ -1,6 +1,7 @@
 export declare const recordCodio: (destination: Uri, workspaceRoot?: Uri, getCodioName?: () => Promise<string>) => void;
 export declare const finishRecording: () => Promise<void>;
 export declare const playCodio: (source: Uri, workspaceUri?: Uri) => void;
+export declare const playCodioTask: (source: Uri, workspaceUri?: Uri) => void;
 export declare const pauseCodio: () => void;
 export declare const pauseOrResume: () => void;
 export declare const resumeCodio: () => void;

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,6 +38,7 @@
         "onCommand:codio.recordCodioAndAddToProject",
         "onCommand:codio.finishRecording",
         "onCommand:codio.playCodio",
+        "onCommand:codio.playCodioTask",
         "onCommand:codio.pauseRecording",
         "onCommand:codio.resumeCodio",
         "onCommand:codio.playFrom",
@@ -93,6 +94,11 @@
                 "command": "codio.playCodio",
                 "category": "Codio",
                 "title": "Play Codio"
+            },
+            {
+                "command": "codio.playCodioTask",
+                "category": "Codio",
+                "title": "Play Codio from Task"
             },
             {
                 "command": "codio.pauseCodio",

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -1,6 +1,7 @@
 import executeFile from './executeFile';
 import pauseOrResume from './pauseOrResume';
 import playCodio from './playCodio';
+import playCodioTask from './playCodioTask';
 import { forward, rewind } from './rewindAndForward';
 import playFrom from './playFrom';
 import resumeCodio from './resumeCodio';
@@ -12,6 +13,7 @@ export {
   executeFile,
   pauseOrResume,
   playCodio,
+  playCodioTask,
   forward,
   rewind,
   playFrom,

--- a/vscode/src/commands/playCodioTask.ts
+++ b/vscode/src/commands/playCodioTask.ts
@@ -1,0 +1,21 @@
+import { Uri } from 'vscode';
+import Player from '../player/Player';
+import Recorder from '../recorder/Recorder';
+import FSManager from '../filesystem/FSManager';
+import playCodio from './playCodio';
+
+export default async function playCodioTask(
+  fsManager: FSManager,
+  player: Player,
+  recorder: Recorder,
+  codioUri?: Uri,
+  workspaceUri?: Uri,
+) {
+  //  When a command is executed from 'tasks.json' the first parameter is an array
+  //  consisting of the command and project folder.
+  if (!codioUri || Array.isArray(codioUri)) {
+    const codios = await fsManager.getAllCodiosMetadata();
+    codioUri = codios.length === 1 ? codios[0].uri : '';
+  }
+  playCodio(fsManager, player, recorder, codioUri, workspaceUri);
+}

--- a/vscode/src/consts/command_names.ts
+++ b/vscode/src/consts/command_names.ts
@@ -1,4 +1,5 @@
 export const PLAY_CODIO = 'codio.playCodio';
+export const PLAY_CODIO_TASK = 'codio.playCodioTask';
 export const RECORD_CODIO = 'codio.recordCodio';
 export const FINISH_RECORDING = 'codio.finishRecording';
 export const PAUSE_CODIO = 'codio.pauseCodio';

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -17,6 +17,7 @@ const {
   recordCodio,
   finishRecording,
   playCodio,
+  playCodioTask,
   pauseCodio,
   pauseOrResume,
   resumeCodio,
@@ -25,7 +26,18 @@ const {
   forward,
 } = createSdk(player, recorder, fsManager);
 
-export { recordCodio, finishRecording, playCodio, pauseCodio, pauseOrResume, resumeCodio, playFrom, rewind, forward };
+export {
+  recordCodio,
+  finishRecording,
+  playCodio,
+  playCodioTask,
+  pauseCodio,
+  pauseOrResume,
+  resumeCodio,
+  playFrom,
+  rewind,
+  forward,
+};
 
 export async function activate(context: ExtensionContext) {
   await fsManager.createExtensionFolders();
@@ -60,6 +72,13 @@ export async function activate(context: ExtensionContext) {
     },
   );
 
+  const playCodioTaskDisposable = commands.registerCommand(
+    COMMAND_NAMES.PLAY_CODIO_TASK,
+    async (source: Uri, workspaceUri?: Uri) => {
+      codioCommands.playCodioTask(fsManager, player, recorder, source, workspaceUri);
+    },
+  );
+
   const pauseCodioDisposable = commands.registerCommand(COMMAND_NAMES.PAUSE_CODIO, () => {
     codioCommands.pauseCodio(player);
   });
@@ -91,6 +110,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(recordCodioDisposable);
   context.subscriptions.push(finishRecordingDisposable);
   context.subscriptions.push(playCodioDisposable);
+  context.subscriptions.push(playCodioTaskDisposable);
   context.subscriptions.push(pauseCodioDisposable);
   context.subscriptions.push(resumeCodioDisposable);
   context.subscriptions.push(playFromDisposable);

--- a/vscode/src/sdk.ts
+++ b/vscode/src/sdk.ts
@@ -19,6 +19,10 @@ export function createSdk(player: Player, recorder: Recorder, fsManager: FSManag
     codioCommands.playCodio(fsManager, player, recorder, source, workspaceUri);
   };
 
+  const playCodioTask = async (source: Uri, workspaceUri?: Uri) => {
+    codioCommands.playCodioTask(fsManager, player, recorder, source, workspaceUri);
+  };
+
   const finishRecording = () => codioCommands.finishRecording(recorder);
   const pauseCodio = () => codioCommands.pauseCodio(player);
   const pauseOrResume = () => codioCommands.pauseOrResume(player);
@@ -31,6 +35,7 @@ export function createSdk(player: Player, recorder: Recorder, fsManager: FSManag
     recordCodio,
     finishRecording,
     playCodio,
+    playCodioTask,
     pauseCodio,
     pauseOrResume,
     resumeCodio,


### PR DESCRIPTION
Adding the handling the playing of first codio when executed from tasks.json.

Example './.vscode/tasks.json' file:
```
{
  // See https://go.microsoft.com/fwlink/?LinkId=733558
  // for the documentation about the tasks.json format
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Codio",
      "type": "shell",
      "command": "${command:codio.playCodio}",
      "presentation": {
        "reveal": "always",
        "panel": "new"
      },
      "runOptions": { "runOn": "folderOpen" }
    }
  ]
}    
```

Otherwise the error received is:

```
Play codio failed TypeError [ERR_INVALID_ARG_TYPE]: 
The "path" argument must be one of type string, Buffer,
or URL. Received type undefined 
```