### PR TITLE
Create Frame Bug Fix

### DIFF
--- a/vscode/src/editor/frame/create_frame.ts
+++ b/vscode/src/editor/frame/create_frame.ts
@@ -27,7 +27,7 @@ export function createFrame(initialFrame: Array<CodioFile>, timeline: Array<Codi
   const documentsByPath = initialFrametoDocumentsByPath(initialFrame);
 
   timeline.forEach((event) => {
-    if (isTextEvent(event)) {
+    if (isTextEvent(event) && event.data.uri) {
       const document: ShadowDocument = documentsByPath[event.data.uri.path].document;
       event.data.changes.forEach((change) => {
         if (change.position) {


### PR DESCRIPTION
Added guard against a codio text event with no `uri` property. This error occurred "`play from fail TypeError: Cannot read property 'path' of undefined`" when this event object was encountered:
```
{
  "type": "text",
  "data": {
    "changes": [
      {
        "range": [
          {
            "line": 23,
            "character": 0
          },
          {
            "line": 23,
            "character": 48
          }
        ],
        "value": "    \"workbench.startupEditor\": \"newUntitledFile\",\n    \"liveServer.settings.donotVerifyTags\": true"
      }
    ],
    "time": 211699,
    "path": ""
  }
}
```
It would crash the audio portion of the codio. From reviewing the code it seems that the `Editor` would `serializeEvents` from the `getTimelineContent` method when the `Recorder` saves a recording (`saveRecording`). This could stem from what the value data is and be a further underlining problem. Please advise if so.
