### PR TITLE
Fix Workspace Bug

### DIFF
--- a/vscode/src/filesystem/workspace.ts
+++ b/vscode/src/filesystem/workspace.ts
@@ -11,17 +11,23 @@ const createWorkspaceCodiosFolder = async (workspaceUri: Uri) => {
 };
 
 export const getWorkspaceUriAndCodioDestinationUri = async () => {
+  let workspaceUri = null;
+  let codioUri = null;
+  let getCodioName = null;
+
   if (workspace.workspaceFolders) {
     const name = await showCodioNameInputBox();
     if (name) {
-      const workspaceUri = workspace.workspaceFolders[0].uri;
+      workspaceUri = workspace.workspaceFolders[0].uri;
       const codioWorkspaceFolderPath = await createWorkspaceCodiosFolder(workspaceUri);
-      const codioUri = Uri.file(join(codioWorkspaceFolderPath, `${name.split(' ').join('_')}.codio`));
-      return { workspaceUri, codioUri, getCodioName: async () => name };
+      codioUri = Uri.file(join(codioWorkspaceFolderPath, `${name.split(' ').join('_')}.codio`));
+      getCodioName = async () => name;
     }
   } else {
     UI.showMessage(MESSAGES.noActiveWorkspace);
   }
+
+  return { workspaceUri, codioUri, getCodioName };
 };
 
 export const getWorkspaceRootAndCodiosFolderIfExists = ():


### PR DESCRIPTION
Fixing bug to return correct number of values when no filename is given.

Weird bug that consisted of two different execution paths hitting the same command but getting different outputs:
Clicking the tree item 'Record Codio' produced:

```
notificationsAlerts.ts:40 Command 'Codio: Record Codio to Project' resulted in an error (Cannot destructure property 'workspaceUri' of '(intermediate value)' as it is undefined.)
```

While clicking on the microphone icon on the view/title resulted with no error but exited early without displaying subsequent console logs. This leads me to believe that there is an internal VS Code bug.

Anyway fixed with this PR.