### PR TITLE
remove tslint extension recommendation (it's deprecated)

### DIFF
--- a/vscode/.vscode/extensions.json
+++ b/vscode/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin"
+
 	]
 }


### PR DESCRIPTION
We currently recommend vscode users install tslint, which is deprecated. This removes that recommendation.