### PR TITLE
Add separate items per codio type

### DIFF
--- a/vscode/src/commands/playCodioTask.ts
+++ b/vscode/src/commands/playCodioTask.ts
@@ -14,7 +14,8 @@ export default async function playCodioTask(
   //  When a command is executed from 'tasks.json' the first parameter is an array
   //  consisting of the command and project folder.
   if (!codioUri || Array.isArray(codioUri)) {
-    const codios = await fsManager.getAllCodiosMetadata();
+    const { workspaceCodios, libraryCodios } = await fsManager.getAllCodiosMetadata();
+    const codios = [...workspaceCodios, ...libraryCodios]
     codioUri = codios.length === 1 ? codios[0].uri : '';
   }
   playCodio(fsManager, player, recorder, codioUri, workspaceUri);

--- a/vscode/src/filesystem/FSManager.ts
+++ b/vscode/src/filesystem/FSManager.ts
@@ -231,12 +231,11 @@ export default class FSManager {
 
   async getAllCodiosMetadata() {
     const workspaceFolders = getWorkspaceRootAndCodiosFolderIfExists();
-    const codioWorkspaceCodios = workspaceFolders
+    const workspaceCodios = workspaceFolders
       ? await this.getCodiosMetadata(workspaceFolders.workspaceCodiosFolder, workspaceFolders.workspaceRootUri)
       : [];
     const libraryCodios = await this.getCodiosMetadata();
-    const allCodios = [...codioWorkspaceCodios, ...libraryCodios];
-    return allCodios;
+    return { workspaceCodios, libraryCodios };
   }
 
   async getCodioMetaDataContent(codioFolderPath) {
@@ -277,7 +276,8 @@ export default class FSManager {
   }
 
   async chooseCodio(): Promise<{ path: string; workspaceRoot?: vscode.Uri } | undefined> {
-    const codios = await this.getAllCodiosMetadata();
+    const { workspaceCodios, libraryCodios } = await fsManager.getAllCodiosMetadata();
+    const codios = [...workspaceCodios, ...libraryCodios]
     return this.choose(codios);
   }
 }

--- a/vscode/src/user_interface/Viewers.ts
+++ b/vscode/src/user_interface/Viewers.ts
@@ -34,36 +34,55 @@ export class CodiosDataProvider implements vscode.TreeDataProvider<vscode.TreeIt
   }
 
   async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
-    if (element) {
-      return [element];
-    } else {
-      const allCodios = await this.fsManager.getAllCodiosMetadata();
-      if (allCodios.length > 0) {
-        return allCodios.map((codio) => {
-          const codioItem = new vscode.TreeItem(codio.name);
-          codioItem.iconPath = {
-            dark: join(this.extensionPath, 'media/icon-small.svg'),
-            light: join(this.extensionPath, 'media/icon-small-light.svg'),
-          };
-          codioItem.command = { command: PLAY_CODIO, title: 'Play Codio', arguments: [codio.uri, codio.workspaceRoot] };
-          codioItem.contextValue = 'codio';
-          return codioItem;
-        });
-      } else {
-        const recordCodioItem = new vscode.TreeItem('Record Codio');
-        recordCodioItem.iconPath = {
-          dark: join(this.extensionPath, 'media/microphone.svg'),
-          light: join(this.extensionPath, 'media/microphone-light.svg'),
-        };
-        recordCodioItem.command = {
-          command: RECORD_CODIO_AND_ADD_TO_PROJECT,
-          title: 'Record Codio and Add to Project',
-          arguments: [],
-        };
-        recordCodioItem.contextValue = 'codio';
-        return [recordCodioItem];
-      }
+    const { workspaceCodios, libraryCodios } = await this.fsManager.getAllCodiosMetadata();
+    const allCodios = [...workspaceCodios, ...libraryCodios];
+
+    if (!allCodios.length) {
+      return [new RecordActionItem(this.extensionPath)];
     }
+
+    if (!element) {
+      return [
+        new vscode.TreeItem('Workspace Codios', vscode.TreeItemCollapsibleState.Collapsed),
+        new vscode.TreeItem('Library Codios', vscode.TreeItemCollapsibleState.Collapsed),
+      ];
+    }
+
+    if (element.label === 'Workspace Codios') {
+      return workspaceCodios.map((codio) => new CodioItem(codio, this.extensionPath));
+    }
+
+    if (element.label === 'Library Codios') {
+      return libraryCodios.map((codio) => new CodioItem(codio, this.extensionPath));
+    }
+  }
+}
+
+class RecordActionItem extends vscode.TreeItem {
+  constructor(extensionPath: string) {
+    super('Record Codio');
+    this.iconPath = {
+      dark: join(extensionPath, 'media/microphone.svg'),
+      light: join(extensionPath, 'media/microphone-light.svg'),
+    };
+    this.command = {
+      command: RECORD_CODIO_AND_ADD_TO_PROJECT,
+      title: 'Record Codio and Add to Project',
+      arguments: [],
+    };
+    this.contextValue = 'codio';
+  } 
+}
+
+class CodioItem extends vscode.TreeItem {
+  constructor(codio: { name: string; uri: string; workspaceRoot: string }, extensionPath: string) {
+    super(codio.name);
+    this.iconPath = {
+      dark: join(extensionPath, 'media/icon-small.svg'),
+      light: join(extensionPath, 'media/icon-small-light.svg'),
+    };
+    this.command = { command: PLAY_CODIO, title: 'Play Codio', arguments: [codio.uri, codio.workspaceRoot] };
+    this.contextValue = 'codio';
   }
 }
 


### PR DESCRIPTION
First step for supporting library codios. I create a separate items per type `Wokspace` and `Library` codios
<img width="1783" alt="Screenshot 2021-01-27 at 18 52 39" src="https://user-images.githubusercontent.com/8109789/106024827-d6508f80-60d0-11eb-96af-e705a483e891.png">
